### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @uktrade/data-infrastructure


### PR DESCRIPTION
So it's clear which team owns this, and to automatically invite to review