### PR TITLE
feat: allow non-base64 encoded payloads

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,13 +65,10 @@ def lambda_handler(event, context):
             'body': 'There must be a request body',
         }
 
-    if not event.get('isBase64Encoded'):
-        return {
-            'statusCode': 500,
-            'body': 'Internal error: the request body has the wrong encoding',
-        }
-
-    body_bytes = b64decode(body)
+    body_bytes = \
+        b64decode(body) if event.get('isBase64Encoded') else \
+        body.encode('utf-8')
+    
     key = f'{datetime.now().isoformat()}-{uuid4()}'
     s3_client.put_object(Bucket=os.environ['BUCKET'], Key=key, Body=body_bytes)
 


### PR DESCRIPTION
If the sender sends application/json, then the Lambda system does _not_ base64 encode the body. So to get the original bytes, we need to encode the payload.

(Technically if the payload was encoded using something other than utf-8, this won't be the original bytes, but for our purposes we can live with that)